### PR TITLE
fix location of kitsap key and bike

### DIFF
--- a/kitsap-bike-parking.csv
+++ b/kitsap-bike-parking.csv
@@ -32,7 +32,7 @@ SAARS SUPERMARKET WHEATON,"2900 Wheaton Way, Bremerton, WA 98310",right of entra
 SEASIDE CHURCH BREMERTON,"1317 Sheldon Blvd, Bremerton, WA 98337",right of entrance,WAVE,NO,3,Seaside Church - Bremerton.jpg,-122.6295,47.57331
 FRED MEYER - BREMERTON SOUTH,"5050 WA-303, Bremerton, WA 98311",near Panda Inn,WAVE,NO,3,Fred Meyer Bremerton South.jpg,-122.62761,47.61008
 SAFEWAY - WEST BREMERTON,"900 N Callow Ave, Bremerton, WA 98312","Some near front, some on side near Callow",WAVE,YES,22,NA,-122.65273,47.57011
-KITSAP KEY AND BIKE,"306 N Callow Ave, Bremerton, WA 98312","Near door, only during open hours",GRID,YES,4,NA,-122.6552619,47.565849300000004
+KITSAP KEY AND BIKE,"306 N Callow Ave, Bremerton, WA 98312","Near door, only during open hours",GRID,YES,4,NA,-122.6531742,47.56586108
 BREMERTON FERRY TERMINAL,"100 Washington Ave, Bremerton, WA 98337",Lower level near foot ferry entrance,BOLLARD,YES,30,NA,-122.624654,47.562583
 TARGET SILVERDALE,"3201 NW Randall Way, Silverdale, WA 98383",to the right of entrance,WAVE,NO,4,Target Silverdale.jpg,-122.69434,47.65781
 ROUND TABLE SILVERDALE,"3276 NW Plaza Rd #101, Silverdale, WA 98383",right out front,GRID,NO,2,Round Table Silverdale.jpg,-122.69459,47.65693


### PR DESCRIPTION
The previous lat/lon made the rack appear to be between N Cambrian Ave and Meade Ave, rather than on the east side of N Callow Ave

Also, just stumbled upon this list, kudos!